### PR TITLE
LocalCache backend for open-uri-memcached

### DIFF
--- a/lib/openuri/local-cache.rb
+++ b/lib/openuri/local-cache.rb
@@ -1,0 +1,30 @@
+require 'openuri/common'
+
+begin
+  require 'minigems'
+rescue LoadError
+  require 'rubygems'
+end
+
+gem "local_cache", ">= 1.2.2"
+require 'local_cache'
+
+module OpenURI
+  class Cache
+    class << self
+      # Enable caching
+      def enable!
+        @cache ||= LocalCache.new
+        @cache_enabled = true
+      end
+      
+      def get(key)
+        @cache.read(key) 
+      end
+      
+      def set(key, value)
+        @cache.write(key, value, :ttl => expiry)
+      end
+    end
+  end
+end

--- a/open-uri-memcached.gemspec
+++ b/open-uri-memcached.gemspec
@@ -1,10 +1,12 @@
 Gem::Specification.new do |s|
   s.name = "openuri_memcached"
-  s.version = '0.2.1'
+  s.version = '0.2.1.1'
   s.email = "ben@germanforblack.com"
   s.homepage = "http://github.com/benschwarz/open-uri-memcached"
   s.description = "OpenURI with transparent caching"
   s.authors = ["Ben Schwarz"]
   s.summary = "The same OpenURI that you know and love with the power of Memcached"
-  s.files = %w(README.markdown History.txt License.txt lib/openuri_memcached.rb lib/openuri/memcached.rb lib/openuri/common.rb lib/openuri/rails-cache.rb)
+  s.files = %w(README.markdown History.txt License.txt 
+		lib/openuri_memcached.rb lib/openuri/memcached.rb lib/openuri/common.rb 
+		lib/openuri/rails-cache.rb lib/openuri/local-cache.rb)
 end

--- a/spec/openuri_cache_spec.rb
+++ b/spec/openuri_cache_spec.rb
@@ -133,7 +133,12 @@ logger = Logger.new(StringIO.new)
     before :all do
       Rails.cache = ActiveSupport::Cache::MemCacheStore.new('127.0.0.1:11211')
     end
+  },
+  'local-cache' => lambda {
+    require 'local_cache'
+    require 'openuri/local-cache'
   }
+
 }.each do |key, before|
   begin
     describe key do


### PR DESCRIPTION
Hi, I just added a new backend to your gem. It is similar to the rails-cache one, however doesn't require using Rails, just local cache (which depends on active-support). This greatly reduces the ammount of required gems for non-rails projects.
