### PR TITLE
allow openuri memcached to be used with new memcached versions

### DIFF
--- a/lib/openuri/memcached.rb
+++ b/lib/openuri/memcached.rb
@@ -14,7 +14,7 @@ module OpenURI
     class << self
       # Enable caching
       def enable!
-        @cache ||= Memcached.new(host, {
+        @cache ||= Memcached::Rails.new(host, {
           :namespace => 'openuri', 
           :no_block => true,
           :buffer_requests => true


### PR DESCRIPTION
The memcache version here is ancient. This patch will allow backwards compatibility.
